### PR TITLE
Add reusable Button component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,9 @@
+import Button from "@/components/Button";
+
 export default function Home() {
+  const handleClick = () => {
+    alert("Button clicked!");
+  };
   return (
     <div className="p-6">
       <h1 className="text-3xl font-bold">
@@ -8,6 +13,14 @@ export default function Home() {
       <p className="mt-2 text-gray-600">
         Explore the About, Contact, and Quotes pages using the navigation above.
       </p>
+      <div className="mt-6">
+        <Button label="Click Me" onClick={handleClick} />
+        <Button
+          label="Secondary Button"
+          variant="secondary"
+          onClick={handleClick}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+interface ButtonProps {
+  label: string;
+  onClick?: () => void;
+  variant?: "primary" | "secondary";
+}
+
+const Button: React.FC<ButtonProps> = ({
+  label,
+  onClick,
+  variant = "primary",
+}) => {
+  const baseStyle = "px-4 py-2 rounded font-semibold transition duration-200";
+
+  const variants = {
+    primary: "bg-blue-600 text-white hover:bg-blue-700",
+    secondary: "bg-gray-200 text-gray-800 hover:bg-gray-300",
+  };
+
+  return (
+    <button className={`${baseStyle} ${variants[variant]}`} onClick={onClick}>
+      {label}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
This PR adds a reusable Button component with primary and secondary variants.  
Demonstrated usage on the Home page.  
Closes #7 